### PR TITLE
feat: add user get all structure and custom response format

### DIFF
--- a/src/main/java/com/usermanagement/api/controllers/user/UserController.java
+++ b/src/main/java/com/usermanagement/api/controllers/user/UserController.java
@@ -21,7 +21,7 @@ public class UserController {
   @Autowired private IUserService userService;
   @Autowired private ResponseUtil responseUtil;
 
-  public ServerResponse createUserRoute(ServerRequest request)
+  public ServerResponse createUserController(ServerRequest request)
       throws ServletException, IOException {
     UserRequestDTO user = request.body(UserRequestDTO.class);
     UserResponseDTO serviceResponse = userService.createUser(user);
@@ -29,12 +29,17 @@ public class UserController {
         HttpStatus.CREATED, "User created", Map.of("user", serviceResponse));
   }
 
-  public ServerResponse updateUserRoute(ServerRequest request)
+  public ServerResponse updateUserController(ServerRequest request)
       throws ServletException, IOException {
     String id = request.pathVariable("id");
     UserRequestDTO user = request.body(UserRequestDTO.class);
     UserResponseDTO serviceResponse = userService.updateUser(id, user);
     return responseUtil.jsonResponse(
         HttpStatus.OK, "User updated", Map.of("user", serviceResponse));
+  }
+
+  public ServerResponse getAllUsersController(ServerRequest request) {
+    var serviceResponse = userService.getAllUsers();
+    return responseUtil.jsonResponse(HttpStatus.OK, "Founded!", serviceResponse);
   }
 }

--- a/src/main/java/com/usermanagement/api/routes/user/UserRoutes.java
+++ b/src/main/java/com/usermanagement/api/routes/user/UserRoutes.java
@@ -2,6 +2,7 @@
 
 package com.usermanagement.api.routes.user;
 
+import static org.springframework.web.servlet.function.RequestPredicates.GET;
 import static org.springframework.web.servlet.function.RequestPredicates.PATCH;
 import static org.springframework.web.servlet.function.RequestPredicates.POST;
 import static org.springframework.web.servlet.function.RouterFunctions.route;
@@ -21,7 +22,8 @@ public class UserRoutes {
   }
 
   public RouterFunction<ServerResponse> userRouter() {
-    return route(POST("/users"), controller::createUserRoute)
-        .andRoute(PATCH("/users/{id}"), controller::updateUserRoute);
+    return route(POST("/users"), controller::createUserController)
+        .andRoute(PATCH("/users/{id}"), controller::updateUserController)
+        .andRoute(GET("/users"), controller::getAllUsersController);
   }
 }

--- a/src/main/java/com/usermanagement/infrastructure/repositories/user/IUserRepository.java
+++ b/src/main/java/com/usermanagement/infrastructure/repositories/user/IUserRepository.java
@@ -3,6 +3,7 @@
 package com.usermanagement.infrastructure.repositories.user;
 
 import com.usermanagement.infrastructure.models.user.UserEntity;
+import java.util.List;
 
 public interface IUserRepository {
   UserEntity createUser(UserEntity user);
@@ -12,4 +13,6 @@ public interface IUserRepository {
   UserEntity findUserById(String id);
 
   UserEntity updateUser(UserEntity user);
+
+  List<UserEntity> findAllUsers();
 }

--- a/src/main/java/com/usermanagement/infrastructure/repositories/user/impl/UserRepositoryImpl.java
+++ b/src/main/java/com/usermanagement/infrastructure/repositories/user/impl/UserRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.usermanagement.infrastructure.repositories.user.IUserRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
 import jakarta.transaction.Transactional;
+import java.util.List;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -41,5 +42,12 @@ public class UserRepositoryImpl implements IUserRepository {
   @Transactional
   public UserEntity updateUser(UserEntity user) {
     return entityManager.merge(user);
+  }
+
+  @Override
+  public List<UserEntity> findAllUsers() {
+    return entityManager
+        .createQuery("SELECT u FROM UserEntity u", UserEntity.class)
+        .getResultList();
   }
 }

--- a/src/main/java/com/usermanagement/services/user/IUserService.java
+++ b/src/main/java/com/usermanagement/services/user/IUserService.java
@@ -4,10 +4,13 @@ package com.usermanagement.services.user;
 
 import com.usermanagement.core.dtos.user.UserRequestDTO;
 import com.usermanagement.core.dtos.user.UserResponseDTO;
+import java.util.Map;
 
 public interface IUserService {
 
   UserResponseDTO createUser(UserRequestDTO user);
 
   UserResponseDTO updateUser(String id, UserRequestDTO user);
+
+  Map<String, Map<String, Object>> getAllUsers();
 }

--- a/src/main/java/com/usermanagement/services/user/impl/UserServiceImpl.java
+++ b/src/main/java/com/usermanagement/services/user/impl/UserServiceImpl.java
@@ -13,6 +13,8 @@ import com.usermanagement.infrastructure.repositories.user.IUserRepository;
 import com.usermanagement.services.user.IUserService;
 import com.usermanagement.services.user.utils.UserServiceUtils;
 import com.usermanagement.utils.LoggerUtil;
+import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -81,6 +83,14 @@ public class UserServiceImpl implements IUserService {
       LoggerUtil.error("Unexpected error during user update: " + e.getMessage());
       throw new RuntimeException("Failed to update user", e);
     }
+  }
+
+  @Override
+  public Map<String, Map<String, Object>> getAllUsers() {
+    List<UserResponseDTO> dtos =
+        userRepository.findAllUsers().stream().map(userMapper::toResponseDTO).toList();
+
+    return UserServiceUtils.formatUsersAsMap(dtos);
   }
 
   private void checkUserEmail(String email) {

--- a/src/main/java/com/usermanagement/services/user/utils/UserServiceUtils.java
+++ b/src/main/java/com/usermanagement/services/user/utils/UserServiceUtils.java
@@ -2,6 +2,9 @@ package com.usermanagement.services.user.utils;
 
 import com.usermanagement.core.dtos.user.UserResponseDTO;
 import com.usermanagement.infrastructure.models.user.UserEntity;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
@@ -22,6 +25,17 @@ public class UserServiceUtils {
 
   public static UserResponseDTO entityConvertToResponseDTO(UserEntity user) {
     return new UserResponseDTO(user.getId(), user.getName(), user.getEmail());
+  }
+
+  public static Map<String, Map<String, Object>> formatUsersAsMap(List<UserResponseDTO> users) {
+    return users.stream()
+        .collect(
+            Collectors.toMap(
+                UserResponseDTO::getId,
+                user ->
+                    Map.of(
+                        "name", user.getName(),
+                        "email", user.getEmail())));
   }
 
   private UserServiceUtils() {

--- a/src/main/java/com/usermanagement/utils/ResponseUtil.java
+++ b/src/main/java/com/usermanagement/utils/ResponseUtil.java
@@ -11,7 +11,7 @@ import org.springframework.web.servlet.function.ServerResponse;
 @Component
 public class ResponseUtil {
 
-  public ServerResponse jsonResponse(HttpStatus status, String message, Map<String, Object> data) {
+  public ServerResponse jsonResponse(HttpStatus status, String message, Map<?, ?> data) {
     Map<String, Object> body = new LinkedHashMap<>();
     body.put("status_code", status.value());
     body.put("status_name", status.getReasonPhrase());


### PR DESCRIPTION
### ✅ **What was done**
- 🚀 Implemented the `GET /users` endpoint to retrieve all users  
- 🔄 Created a custom structure where each user ID is a key, and its value is a map with name and email  
- 🛠️ Refactored `UserService` and controller to support custom response structure  
- 🧩 Improved `ResponseUtil` to support dynamic return structures  
- 🧪 Added validation for missing user data during listing  

---

### 🧠 **Motivation**
This structure was introduced to enhance flexibility and clarity for frontend consumption:

- More accessible format for mapping and rendering user data  
- Easier parsing on frontend with ID-based structure  
- More control over the shape of the API response  
- Sets the foundation for future filtering and pagination  
